### PR TITLE
$rootElementProvider error fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 .history/
+.vscode/

--- a/README.md
+++ b/README.md
@@ -41,4 +41,32 @@ storiesOf("Components/Demo", module)
   );
 ```
 
+or if you need to define any dependencies for your component:
+
+```js
+import { storiesOf } from "@storybook/html";
+
+import { withKnobs, text, number } from "@storybook/addon-knobs";
+import { action } from "@storybook/addon-actions";
+
+import { forModule } from "storybook-addon-angularjs";
+
+storiesOf("Components/Demo", module)
+  .addDecorator(withKnobs)
+  .add(
+    "default",
+    forModule(["ngMaterial", "myApp"]).createElement(compile => {
+      const name = text("Name", "Jane");
+
+      const foo = {
+        bar: number("Value", 20, { range: true, min: 0, max: 30, step: 1 })
+      };
+
+      const onEvt = action("clicked");
+
+      return compile`<demo-component name="${name}" foo="${foo}" on-ev="${onEvt}(num, name)"></demo-component>`;
+    })
+  );
+```
+
 See a full working example [here](https://github.com/titonobre/storybook-addon-angularjs-example).

--- a/lib/utils/angularjs.js
+++ b/lib/utils/angularjs.js
@@ -4,13 +4,30 @@ import angular from "angular";
  * Compiles the given template with the given scope into the given element.
  *
  * @param {HTMLElement} element the root element to compile
- * @param {string} moduleName the name of the module
+ * @param {string|string[]} moduleName the name of the module
  * @param {string} template the new HTML to compile
  * @param {any} newScope the new scope
  */
 function compile(moduleName, element, template, newScope = {}) {
-  const $injector = angular.injector(["ng", moduleName]);
   const $element = angular.element(element);
+  let $injector;
+
+  if (typeof moduleName === "string") {
+    $injector = angular.injector(["ng", moduleName]);
+  } else if (Array.isArray(moduleName)) {
+    try {
+      $injector = angular.injector(["ng", ...moduleName]);
+    } catch (err) {
+      if (
+        err &&
+        err instanceof Error &&
+        err.message.includes("$rootElementProvider")
+      ) {
+        const tmpModule = createRootElementModule($element);
+        $injector = angular.injector(["ng", tmpModule.name, ...moduleName]);
+      }
+    }
+  }
 
   const compiler = function($compile, $rootScope) {
     // get the scope of the target, use the rootScope if it does not exists
@@ -30,13 +47,30 @@ function compile(moduleName, element, template, newScope = {}) {
 /**
  * Updates the given element with the given scope.
  *
- * @param {string} moduleName the name of the module
+ * @param {string|string[]} moduleName the name of the module
  * @param {HTMLElement} element the root element to update
  * @param {any} newScope the new scope
  */
 function update(moduleName, element, newScope) {
-  const $injector = angular.injector(["ng", moduleName]);
   const $element = angular.element(element);
+  let $injector;
+
+  if (typeof moduleName === "string") {
+    $injector = angular.injector(["ng", moduleName]);
+  } else if (Array.isArray(moduleName)) {
+    try {
+      $injector = angular.injector(["ng", ...moduleName]);
+    } catch (err) {
+      if (
+        err &&
+        err instanceof Error &&
+        err.message.includes("$rootElementProvider")
+      ) {
+        const tmpModule = createRootElementModule($element);
+        $injector = angular.injector(["ng", tmpModule.name, ...moduleName]);
+      }
+    }
+  }
 
   const updater = function($rootScope) {
     const $scope = $element.scope();
@@ -52,10 +86,20 @@ function update(moduleName, element, newScope) {
   $injector.invoke(updater);
 }
 
+function createRootElementModule(element) {
+  return angular
+    .module("_rootElement", [])
+    .provider("$rootElement", function() {
+      this.$get = function() {
+        return element;
+      }
+    });
+}
+
 /**
  * Creates an new element with the given template and the given scope.
  *
- * @param {string} moduleName the angularjs module
+ * @param {string|string[]} moduleName the angularjs module
  * @param {string} template the new template
  * @param {any} scope the scope for the new element
  */
@@ -70,7 +114,7 @@ function createElement(moduleName, template, scope = {}) {
 /**
  * Updates the given element with the given scope.
  *
- * @param {string} moduleName the angularjs module
+ * @param {string|string[]} moduleName the angularjs module
  * @param {HTMLElement} element the element to update
  * @param {any} scope the new scope
  */

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,14 @@
 {
   "name": "storybook-addon-angularjs",
   "version": "0.0.2",
-  "lockfileVersion": 1
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "angular": {
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/angular/-/angular-1.7.4.tgz",
+      "integrity": "sha512-nYTWc9CpZjTY57l8EA1+DGpQNzI6HewQ34bfRYoGXBYysIoPYjfcgTGWC+Vl3AaeCnhAb3VTkysVESvCBpUIoA==",
+      "dev": true
+    }
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "storybook-addon-angularjs",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "A simple addon to create Storybook stories with AngularJS components.",
   "main": "lib/index.js",
   "keywords": [
@@ -12,5 +12,8 @@
   "repository": "github:titonobre/storybook-addon-angularjs",
   "peerDependencies": {
     "angular": "1.x"
+  },
+  "devDependencies": {
+    "angular": "^1.7.4"
   }
 }


### PR DESCRIPTION
Hi! I just wanted to start out with **Thank You** for making this addon for AngularJS 1.x, since no one else seemed to have any plans and it was a much better approach than my solution. Now, while it does work for mostly everything, the one thing it doesn't work with (I found), is any modules that require a `$rootElement` to be set (the `$rootElement` is set at application bootstrap, but since we're not bootstrapping the app because we're using `$injector` instead, this will throw an error). After looking online for a solution, I saw a lot of people saying to create a dummy module that contains this `$rootElement` set.

Now, I also added the ability to send either a `string` or a `string[]` for the module name, because we have some components that are more atomized (they wrap elements), and so you can't exactly know what modules to require when creating the component (we have some components that we will sometimes use Angular Material with, but other times not).

Let me know if you have any questions. Thanks.