### PR TITLE
Add support for initialize multiple modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,12 @@ This is a simple Quote Card:
 
 See these and more examples in the [example subfolder](./example).
 
+## API
+
+### `withAngularJs(module?: string | string[])`
+
+Storybook decorator. Can optionally be used to initialize the module(s) used within the story.
+
 ## License
 
 Use of this source code is governed by an MIT-style license that can be found in the [LICENSE](LICENSE) file.

--- a/example/stories/examples/new-syntax.stories.js
+++ b/example/stories/examples/new-syntax.stories.js
@@ -83,3 +83,41 @@ example2.story = {
   // adding the decorator with module name only
   decorators: [withAngularJs("myApp")]
 };
+
+/**
+ * Story with multiple modules.
+ */
+export const example3 = () => ({
+  template: `
+    <demo-component
+      name="name"
+      some-string="{{someString}}"
+      foo="foo"
+      things="things"
+      on-event="onEvt(item)">
+    </demo-component>
+    <quote-card
+      author="author"
+      on-click="onEvt(foo)">
+      {{content}}
+    </quote-cardauthor="author">
+  `,
+  props: {
+    content: text("Content", "It works with Knobs and Actions!", "quoteCard"),
+    author: text("Author", "Me", "quoteCard"),
+    things: array("Things", ["a", "b", "c"], ",", "DemoComponent"),
+    foo: {
+      bar: number("Value", 20, { range: true, min: 0, max: 30, step: 1 }, "DemoComponent")
+    },
+    name: text("Name", "Jane", "DemoComponent"),
+    someString: text("Some String", "It works too!",  "DemoComponent"),
+    onEvt: action("clicked")
+  }
+});
+
+example3.story = {
+  // adding the decorator with module name only
+  decorators: [
+    withAngularJs(["myApp.components.demo", "myApp.components.quoteCard"])
+  ]
+};

--- a/lib/decorator.js
+++ b/lib/decorator.js
@@ -15,7 +15,8 @@ export default makeDecorator({
     const storyOptions = parameters || options;
 
     const { module, hooks } =
-      typeof storyOptions === "string"
+      // withAngularJs("myApp") or withAngularJs(["myApp", "myOtherApp"])
+      typeof storyOptions === "string" || Array.isArray(storyOptions)
         ? {
             module: storyOptions,
             hooks: undefined
@@ -23,6 +24,7 @@ export default makeDecorator({
         : storyOptions;
 
     const story = getStory();
+    const modules = Array.isArray(module) ? module : [module];
 
     const { template, props = {} } =
       typeof story === "string" ? { template: story } : story;
@@ -32,7 +34,7 @@ export default makeDecorator({
     if (!cache[key] || cache[key].template !== template) {
       const element = document.createElement("div");
 
-      angular.bootstrap(element, [module]);
+      angular.bootstrap(element, modules);
 
       cache[key] = { template, element };
 


### PR DESCRIPTION
Came over a case today where I needed the ability to load multiple modules in a single story.

Because the app I am using Storybook for is pretty large we currently only load the needed submodules in the stories rather than the whole app.
Unfortunately some components are loosely coupled (`$scope` 😫), so we have some components which need to be embedded into other components (from other modules) to work properly.

Because the injector already works with arrays of modules, it's not a big deal to add the support for multiple modules.