### PR TITLE
Export html

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ But you may choose something more advanced:
 import { withKnobs, text } from "@storybook/addon-knobs";
 import { action } from "@storybook/addon-actions";
 
-import { template as html, withAngularJs } from "storybook-addon-angularjs";
+import { html, withAngularJs } from "storybook-addon-angularjs";
 
 export default {
   title: "QuoteCard",

--- a/example/src/components/demo/demo.component.js
+++ b/example/src/components/demo/demo.component.js
@@ -1,15 +1,15 @@
 const componentName = "demoComponent";
 
 const component = {
-  template: `
-      <h1>It works {{$ctrl.name}}</h1>
-      <div>{{$ctrl.someString}}</div>
-      <div>{{$ctrl.foo.bar}}</div>
-      <ul>
-        <li ng-repeat="item in $ctrl.things">
-          <button ng-click="$ctrl.onClick(item)">{{item}}</button>
-        </li>
-      </ul>
+  template: /* HTML */ `
+    <h1>It works {{$ctrl.name}}</h1>
+    <div>{{$ctrl.someString}}</div>
+    <div>{{$ctrl.foo.bar}}</div>
+    <ul>
+      <li ng-repeat="item in $ctrl.things">
+        <button ng-click="$ctrl.onClick(item)">{{item}}</button>
+      </li>
+    </ul>
   `,
   bindings: {
     name: "<",

--- a/example/src/components/example/example.component.js
+++ b/example/src/components/example/example.component.js
@@ -1,9 +1,10 @@
 const componentName = "exampleComponent";
 
 const component = {
-  template: `
+  template: /* HTML */ `
     <style>
-      h2+div, h2+ul {
+      h2 + div,
+      h2 + ul {
         background-color: #ddd;
         padding: 1em;
         cursor: pointer;
@@ -11,19 +12,19 @@ const component = {
     </style>
 
     <h1>Example Component</h1>
-    
+
     <h2>Injected Service</h2>
     <div ng-click="$ctrl.clickSection('service')">{{$ctrl.appService.message}}</div>
-    
+
     <h2>Value</h2>
     <div ng-click="$ctrl.clickSection('value')">{{$ctrl.value}}</div>
 
     <h2>Iterpolated String</h2>
     <div ng-click="$ctrl.clickSection('interpolated-string')">{{$ctrl.string}}</div>
-    
+
     <h2>Transcluded Slot A</h2>
     <div ng-transclude="slotA" ng-click="$ctrl.clickSection('slot-a')"></div>
-    
+
     <h2>Transcluded Slot B</h2>
     <div ng-transclude="slotB" ng-click="$ctrl.clickSection('slot-b')"></div>
   `,

--- a/example/src/components/quote-card/quote-card.component.js
+++ b/example/src/components/quote-card/quote-card.component.js
@@ -3,7 +3,7 @@ import "./quote-card.css";
 const componentName = "quoteCard";
 
 const component = {
-  template: `
+  template: /* HTML */ `
     <blockquote class="card" ng-click="$ctrl.onClick({foo:'bar'})">
       <p class="content" ng-transclude></p>
       <cite>

--- a/example/stories/demos/csf.stories.js
+++ b/example/stories/demos/csf.stories.js
@@ -1,7 +1,7 @@
 import { withKnobs, text } from "@storybook/addon-knobs";
 import { action } from "@storybook/addon-actions";
 
-import { template as html, withAngularJs } from "storybook-addon-angularjs";
+import { html, withAngularJs } from "storybook-addon-angularjs";
 
 export default {
   title: "Demos|CSF Demos",

--- a/example/stories/demos/csf.stories.js
+++ b/example/stories/demos/csf.stories.js
@@ -8,14 +8,14 @@ export default {
   decorators: [withKnobs, withAngularJs("myApp")],
 };
 
-export const simpleTemplate = () => `
+export const simpleTemplate = () => /* HTML */ `
   <quote-card author="'Me'">
     It works with a simple template!
   </quote-card>
 `;
 
 export const templateAndProps = () => ({
-  template: `
+  template: /* HTML */ `
     <quote-card author="author">
       {{content}}
     </quote-card>
@@ -27,7 +27,7 @@ export const templateAndProps = () => ({
 });
 
 export const knobsAndActions = () => ({
-  template: `
+  template: /* HTML */ `
     <quote-card author="author" on-click="onEvt(foo)">
       {{content}}
     </quote-card>

--- a/example/stories/examples/legacy.stories.js
+++ b/example/stories/examples/legacy.stories.js
@@ -23,5 +23,11 @@ export const Demo = forModule("myApp").createElement((compile) => {
 
   const onEvt = action("clicked");
 
-  return compile`<demo-component name="${name}" some-string="{{${someString}}}" foo="${foo}" things="${things}" on-event="${onEvt}(item)"></demo-component>`;
+  return compile/* HTML */ `<demo-component
+    name="${name}"
+    some-string="{{${someString}}}"
+    foo="${foo}"
+    things="${things}"
+    on-event="${onEvt}(item)"
+  ></demo-component>`;
 });

--- a/example/stories/examples/new-syntax.stories.js
+++ b/example/stories/examples/new-syntax.stories.js
@@ -55,12 +55,8 @@ example1.story = {
  * Story with template and props format.
  */
 export const example2 = () => ({
-  template: `
-    <example-component
-      value="aValue"
-      string="{{aString}}"
-      on-click="onClick(section)"
-    >
+  template: /* HTML */ `
+    <example-component value="aValue" string="{{aString}}" on-click="onClick(section)">
       <slot-a>{{slotA}}</slot-a>
       <slot-b>
         <code>foo()</code>
@@ -84,7 +80,7 @@ example2.story = {
  * Story with multiple modules.
  */
 export const example3 = () => ({
-  template: `
+  template: /* HTML */ `
     <demo-component
       name="name"
       some-string="{{someString}}"

--- a/example/stories/examples/new-syntax.stories.js
+++ b/example/stories/examples/new-syntax.stories.js
@@ -1,7 +1,7 @@
 import { withKnobs, text, number, array } from "@storybook/addon-knobs";
 import { action } from "@storybook/addon-actions";
 
-import { template as html, withAngularJs } from "storybook-addon-angularjs";
+import { html, withAngularJs } from "storybook-addon-angularjs";
 
 export default {
   title: "New Syntax",

--- a/lerna.json
+++ b/lerna.json
@@ -1,8 +1,5 @@
 {
-  "packages": [
-    "lib",
-    "example"
-  ],
+  "packages": ["lib", "example"],
   "version": "1.0.0",
   "npmClient": "yarn",
   "useWorkspaces": true

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,3 +1,3 @@
 export { default as withAngularJs } from "./decorator";
 
-export { forModule, processTemplate as template } from "./utils/angularjs";
+export { forModule, processTemplate as template, processTemplate as html } from "./utils/angularjs";


### PR DESCRIPTION
Hi,

have a small suggestion to export the `processTemplate` function also as `html`.
So we can also write:
```js
import { html, withAngularJs } from "storybook-addon-angularjs";
```
instead of:
```js
import { template as html, withAngularJs } from "storybook-addon-angularjs";
```
### Why I would suggest to use `html` as the default rather than `template`?

Prettier!
[Prettier formats](https://prettier.io/blog/2018/11/07/1.15.0.html#html-template-literal-in-javascript) template literals with `` html`<div></div>` `` automatically as HTML code.
So I would suggest that using `html` rather than `template` is a more common choice.

For backward compatibility it keeps the existing `template` export as well.

---
Also added some `` /* HTML */ `<div></div>` ``comments  to make prettier format some more template strings in the example.
