### PR TITLE
Provide module through decorator when using advanced configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,10 +54,10 @@ import { html, withAngularJs } from "storybook-addon-angularjs";
 
 export default {
   title: "QuoteCard",
-  decorators: [withKnobs, withAngularJs],
+  decorators: [withKnobs, withAngularJs /* OR */ withAngularJs("myApp")],
   parameters: {
     ng: {
-      module: "myApp",
+      module: "myApp", // optional when provided in the decorator
       hooks: {
         beforeCompile() {
           // called once before compiling the the component

--- a/example/stories/examples/new-syntax.stories.js
+++ b/example/stories/examples/new-syntax.stories.js
@@ -52,6 +52,50 @@ example1.story = {
 };
 
 /**
+ * This is basically the same as example1 but provides the module in the decorator rather
+ * than through the parameters
+ */
+export const example1_1 = () => {
+  const aValue = text("Value", "Some text here!");
+  const aString = text("String", "This string will be interpolated...");
+
+  const slotA = text("Slot A", "This will be transcluded into the component");
+
+  const onClick = action("onClick");
+
+  return html`
+    <example-component value="${aValue}" string="{{${aString}}}" on-click="${onClick}(section)">
+      <slot-a>{{${slotA}}}</slot-a>
+      <slot-b>
+        <code>foo()</code>
+      </slot-b>
+    </example-component>
+  `;
+};
+
+example1_1.story = {
+  // adding the decorator with its options passed on the parameters parameters
+  name: "Example 1.1",
+  decorators: [withAngularJs("myApp")],
+  parameters: {
+    ng: {
+      hooks: {
+        beforeCompile() {
+          // called once before compiling the the component
+          console.log("[Story Hook] beforeCompile");
+        },
+        beforeUpdate(AppService) {
+          // called before updating the component with new props
+          console.log("[Story Hook] beforeUpdate, updating AppService message");
+
+          AppService.message = "Ahoy!";
+        },
+      },
+    },
+  },
+};
+
+/**
  * Story with template and props format.
  */
 export const example2 = () => ({

--- a/lib/decorator.js
+++ b/lib/decorator.js
@@ -21,7 +21,12 @@ export default makeDecorator({
             module: storyOptions,
             hooks: undefined,
           }
-        : storyOptions;
+        : {
+            // If module is defined in parameters use it otherwise fallback to
+            // module from options
+            ...storyOptions,
+            module: parameters.module || options,
+          };
 
     const story = getStory();
     const modules = Array.isArray(module) ? module : [module];


### PR DESCRIPTION
Just another small fix for a better usability:

Found myself often copy/paste some code between different stories and there is a small inconsistency between the usage with parameters and without parameters in the story:

Without parameters I am able to add the module name through the parameter in `withAngularJs("moduleName")` while with parameters I have to provide the module name through the parameters:

### Without `parameters`:

```js
example.story = {
  decorators: [withAngularJs("myApp")],
};
```

### With `parameters`:

```js
example.story = {
  decorators: [withAngularJs], // <-- Cannot write withAngularJs("myApp") here
  parameters: {
    ng: {
      module: "myApp",
      ...
   },
}
```
So this PR adds the ability to use `withAngularJs("moduleName")` and `parameters` together.
Also added a new Example 1.1 which demonstrates the usage in addition to the Example 1.

---
This should be the last PR before I am ready to bring in mocking (should be ready tomorrow).
It was previously part of the upcoming mocking PR but I found it better to split it into two seperate PRs 🙃.