### PR TITLE
Adds mocking api

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,20 @@ import { action } from "@storybook/addon-actions";
 
 import { html, withAngularJs } from "storybook-addon-angularjs";
 
+class MockedAppService {
+  constructor() {
+    this.message = "Mocked message";
+  }
+}
+
+function mockLoggingService($log) {
+  return {
+    log: function(message) {
+      $log.log(message);
+    },
+  }
+}
+
 export default {
   title: "QuoteCard",
   decorators: [withKnobs, withAngularJs /* OR */ withAngularJs("myApp")],
@@ -67,6 +81,22 @@ export default {
           SomeService.setValue("Hi!");
         },
       },
+      mock: {
+        // When the app depends on modules which cannot be provided in the story you can mock them
+        modules: ["some.external.module"],
+        // You can mock / override constants here
+        constants: {
+          API_URL: "https://example.com",
+        },
+        // You can mock / override services here (dependency injection also works)
+        services: {
+          AppService: MockedAppService,
+        },
+        // You can mock / override factories here (dependency injection also works)
+        factories: {
+          LoggingService: mockLoggingService,
+        },
+      }
     },
   },
 };

--- a/example/.storybook/preview.js
+++ b/example/.storybook/preview.js
@@ -1,8 +1,0 @@
-import appModule from "../src/app.module";
-
-// override the service already defined in the module
-appModule.factory("AppService", function AppServiceFactory() {
-  return {
-    message: "Hi Dave!",
-  };
-});

--- a/example/src/mock-test.module.js
+++ b/example/src/mock-test.module.js
@@ -21,8 +21,8 @@ export default angular.module("myApp.mockTest", [myApp.name, "some.external.modu
 
     <h2>Mocked Service (from factory)</h2>
     <div>
-      <button ng-click="$ctrl.increaseFactoryCounter()">Increase Count</button>
-      <div>{{$ctrl.factoryCounter}}</div>
+      <button ng-click="$ctrl.mockedServiceFromFactory.increaseCounter()">Increase Count</button>
+      <div>{{$ctrl.mockedServiceFromFactory.counter}}</div>
     </div>
 
     <h2>Mocked Constant</h2>
@@ -36,12 +36,6 @@ export default angular.module("myApp.mockTest", [myApp.name, "some.external.modu
       this.mockedService = mockedService;
       this.mockedServiceFromFactory = mockedServiceFromFactory;
       this.MOCKED_CONSTANT = MOCKED_CONSTANT;
-
-      this.factoryCounter = 0;
-    }
-
-    increaseFactoryCounter() {
-      this.factoryCounter = this.mockedServiceFromFactory.increaseCounter();
     }
   },
 });

--- a/example/src/mock-test.module.js
+++ b/example/src/mock-test.module.js
@@ -1,0 +1,47 @@
+// ! This module is not able to live on it's own because it's dependencies does not exist !
+// ---
+// The module is used for testing the mocking capability of the storybook plugin so it
+// relies the following things which must be mocked:
+// - module (some.external.module)
+// - service
+// - factory
+// - constant
+import angular from "angular";
+
+import myApp from "./app.module";
+
+export default angular.module("myApp.mockTest", [myApp.name, "some.external.module"]).component("mockTest", {
+  template: /* HTML */ `
+    <h1>Mock Test Component</h1>
+    <h2>Mocked Service</h2>
+    <div>
+      <button ng-click="$ctrl.mockedService.increaseCounter()">Increase Count</button>
+      <div>{{$ctrl.mockedService.counter}}</div>
+    </div>
+
+    <h2>Mocked Service (from factory)</h2>
+    <div>
+      <button ng-click="$ctrl.increaseFactoryCounter()">Increase Count</button>
+      <div>{{$ctrl.factoryCounter}}</div>
+    </div>
+
+    <h2>Mocked Constant</h2>
+    <pre ng-bind="$ctrl.MOCKED_CONSTANT"></pre>
+  `,
+
+  controller: class {
+    static $inject = ["MockedService", "MockedServiceFromFactory", "MOCKED_CONSTANT"];
+
+    constructor(mockedService, mockedServiceFromFactory, MOCKED_CONSTANT) {
+      this.mockedService = mockedService;
+      this.mockedServiceFromFactory = mockedServiceFromFactory;
+      this.MOCKED_CONSTANT = MOCKED_CONSTANT;
+
+      this.factoryCounter = 0;
+    }
+
+    increaseFactoryCounter() {
+      this.factoryCounter = this.mockedServiceFromFactory.increaseCounter();
+    }
+  },
+});

--- a/example/stories/demos/csf.stories.js
+++ b/example/stories/demos/csf.stories.js
@@ -3,9 +3,11 @@ import { action } from "@storybook/addon-actions";
 
 import { html, withAngularJs } from "storybook-addon-angularjs";
 
+import myApp from "../../src/app.module";
+
 export default {
   title: "Demos|CSF Demos",
-  decorators: [withKnobs, withAngularJs("myApp")],
+  decorators: [withKnobs, withAngularJs(myApp.name)],
 };
 
 export const simpleTemplate = () => /* HTML */ `

--- a/example/stories/demos/markdown.stories.mdx
+++ b/example/stories/demos/markdown.stories.mdx
@@ -2,7 +2,9 @@ import { Meta, Story, Preview } from "@storybook/addon-docs/blocks";
 
 import { template as html, withAngularJs } from "storybook-addon-angularjs";
 
-<Meta title="Demos|MDX Demos" decorators={[withAngularJs("myApp")]} />
+import myApp from "../../src/app.module";
+
+<Meta title="Demos|MDX Demos" decorators={[withAngularJs(myApp.name)]} />
 
 # Storybook Addon for AngularJS
 

--- a/example/stories/examples/legacy.stories.js
+++ b/example/stories/examples/legacy.stories.js
@@ -3,6 +3,8 @@ import { action } from "@storybook/addon-actions";
 
 import { forModule } from "storybook-addon-angularjs";
 
+import myApp from "../../src/app.module";
+
 export default {
   title: "Legacy",
   decorators: [withKnobs],
@@ -11,7 +13,7 @@ export default {
 /**
  * The usage of `forModule` is now depreated. Please use the new decorator.
  */
-export const Demo = forModule("myApp").createElement((compile) => {
+export const Demo = forModule(myApp.name).createElement((compile) => {
   const name = text("Name", "Jane");
   const someString = text("Some String", "It works too!");
 

--- a/example/stories/examples/mocks.stories.js
+++ b/example/stories/examples/mocks.stories.js
@@ -28,7 +28,7 @@ function MockedServiceFromFactory() {
   let counter = 0;
 
   return {
-    get counter(){
+    get counter() {
       return counter;
     },
     increaseCounter: () => {

--- a/example/stories/examples/mocks.stories.js
+++ b/example/stories/examples/mocks.stories.js
@@ -28,9 +28,11 @@ function MockedServiceFromFactory() {
   let counter = 0;
 
   return {
-    counter,
+    get counter(){
+      return counter;
+    },
     increaseCounter: () => {
-      return ++counter;
+      return counter++;
     },
   };
 }

--- a/example/stories/examples/mocks.stories.js
+++ b/example/stories/examples/mocks.stories.js
@@ -1,0 +1,58 @@
+import { withAngularJs } from "storybook-addon-angularjs";
+
+import mockTestApp from "../../src/mock-test.module";
+
+export default {
+  title: "Mocks",
+};
+
+/**
+ * Story with template and service mock
+ */
+export const MockComponent = () => ({
+  template: /* HTML */ ` <mock-test></mock-test> `,
+});
+
+class MockedService {
+  constructor() {
+    console.log("[MockedService] New Instance");
+    this.counter = 0;
+  }
+
+  increaseCounter() {
+    this.counter++;
+  }
+}
+
+function MockedServiceFromFactory() {
+  let counter = 0;
+
+  return {
+    counter,
+    increaseCounter: () => {
+      return ++counter;
+    },
+  };
+}
+
+MockComponent.story = {
+  decorators: [withAngularJs(mockTestApp.name)],
+  parameters: {
+    ng: {
+      mock: {
+        // Add modules names which should be mocked
+        modules: ["some.external.module"],
+        // Services
+        services: {
+          MockedService,
+        },
+        factories: {
+          MockedServiceFromFactory,
+        },
+        constants: {
+          MOCKED_CONSTANT: "Mocked constant value",
+        },
+      },
+    },
+  },
+};

--- a/example/stories/examples/new-syntax.stories.js
+++ b/example/stories/examples/new-syntax.stories.js
@@ -3,6 +3,10 @@ import { action } from "@storybook/addon-actions";
 
 import { html, withAngularJs } from "storybook-addon-angularjs";
 
+import myApp from "../../src/app.module";
+import demoApp from "../../src/components/demo";
+import quoteApp from "../../src/components/quote-card";
+
 export default {
   title: "New Syntax",
   decorators: [withKnobs],
@@ -34,7 +38,7 @@ example1.story = {
   decorators: [withAngularJs],
   parameters: {
     ng: {
-      module: "myApp",
+      module: myApp.name,
       hooks: {
         beforeCompile() {
           // called once before compiling the the component
@@ -117,7 +121,7 @@ export const example2 = () => ({
 
 example2.story = {
   // adding the decorator with module name only
-  decorators: [withAngularJs("myApp")],
+  decorators: [withAngularJs(myApp.name)],
 };
 
 /**
@@ -153,5 +157,5 @@ export const example3 = () => ({
 
 example3.story = {
   // adding the decorator with module name only
-  decorators: [withAngularJs(["myApp.components.demo", "myApp.components.quoteCard"])],
+  decorators: [withAngularJs([demoApp.name, quoteApp.name])],
 };

--- a/lib/decorator.js
+++ b/lib/decorator.js
@@ -14,12 +14,13 @@ export default makeDecorator({
   wrapper: (getStory, context, { parameters, options }) => {
     const storyOptions = parameters || options;
 
-    const { module, hooks } =
+    const { module, hooks, mock } =
       // withAngularJs("myApp") or withAngularJs(["myApp", "myOtherApp"])
       typeof storyOptions === "string" || Array.isArray(storyOptions)
         ? {
             module: storyOptions,
             hooks: undefined,
+            mock: undefined,
           }
         : {
             // If module is defined in parameters use it otherwise fallback to
@@ -37,6 +38,39 @@ export default makeDecorator({
 
     if (!cache[key] || cache[key].template !== template) {
       const element = document.createElement("div");
+
+      // Initialize mocked modules
+      if (mock && mock.modules) {
+        mock.modules.forEach((moduleToMock) => {
+          modules.unshift(angular.module(moduleToMock, []).name);
+        });
+      }
+
+      // Initialize mocked providers for constants, services and factories
+      // Since the providers of the last module overrides the ones of the previous modules
+      // we append it to the end of the modules
+      // https://stackoverflow.com/q/37094761/831465
+      if (mock) {
+        modules.push([
+          "$provide",
+          ($provide) => {
+            // Constants
+            angular.forEach(mock.constants, (mockedValue, key) => {
+              $provide.constant(key, mockedValue);
+            });
+
+            // Services
+            angular.forEach(mock.services, (mockedValue, key) => {
+              $provide.service(key, mockedValue);
+            });
+
+            // Factories
+            angular.forEach(mock.factories, (mockedValue, key) => {
+              $provide.factory(key, mockedValue);
+            });
+          },
+        ]);
+      }
 
       angular.bootstrap(element, modules);
 


### PR DESCRIPTION
Okay, this took a few days longer due to the good weather here in Germany but finally finished it. 🙌
Hope you are also doing well during this time :smile: 

I suggest the following API for the mocking:

```js
export default {
  title: "QuoteCard",
  decorators: [withAngularJs("myApp")],
  parameters: {
    ng: {
      module: "myApp", // optional when provided in the decorator
      mock: {
        // When the app depends on modules which cannot be provided in the story you can mock them
        modules: ["some.external.module"],
        // You can mock / override constants here
        constants: {
          API_URL: "https://example.com",
        },
        // You can mock / override services here (dependency injection also works)
        services: {
          AppService: MockedAppService,
        },
        // You can mock / override factories here (dependency injection also works)
        factories: {
          LoggingService: mockLoggingService,
        },
      }
    },
  },
};
```

So it comes with the ability to mock the following things:
- **modules** `["moduleName1", "moduleName2", ...]`
Produces for each module provided a "fake" module with that name (So angular.js thinks the modules are loaded, but are in fact not)
- **constants** `{ CONSTANT_NAME: "value", ... }`
Provides / Replaces a constant with the provided key
- **services** `{ AppService: class AppService { }, ... }`
Provides / Replaces a service with the provided key
- **factories** `{ AppService: function appServiceFactory { return {} }, ... }`
Provides / Replaces a factory with the provided key

Also added a new module (`mock-test.module.js`) and story (`mocks.stories.js`) to test the API.

---

Additionally I removed the global loading of the app through the `preview.js` file and instead load the modules directly in the stories.

If you have any thoughts about the API design let me know I am open to suggestions.