### PR TITLE
fix digest-already-in-progress message when updating props

### DIFF
--- a/lib/utils/angularjs.js
+++ b/lib/utils/angularjs.js
@@ -50,7 +50,7 @@ export function updateElement(element, props = {}, hooks) {
     $injector.invoke(hooks.beforeUpdate);
   }
 
-  const updater = function ($rootScope) {
+  const updater = function () {
     const $scope = $element.scope();
 
     $scope.$applyAsync(() => {
@@ -58,7 +58,7 @@ export function updateElement(element, props = {}, hooks) {
     });
   };
 
-  updater.$inject = ["$rootScope"];
+  updater.$inject = [];
 
   $injector.invoke(updater);
 

--- a/lib/utils/angularjs.js
+++ b/lib/utils/angularjs.js
@@ -53,10 +53,9 @@ export function updateElement(element, props = {}, hooks) {
   const updater = function ($rootScope) {
     const $scope = $element.scope();
 
-    Object.assign($scope, props);
-
-    $scope.$digest();
-    $rootScope.$digest();
+    $scope.$applyAsync(() => {
+      Object.assign($scope, props);
+    });
   };
 
   updater.$inject = ["$rootScope"];


### PR DESCRIPTION
Thank you for a great library. Awesome work!

In my use of it, I'm getting an error "digest already in progress" when changing values in controls/knobs and between switching canvas and docs view.

I've limited the error to [updater method](https://github.com/titonobre/storybook-addon-angularjs/blob/8e38755993c73edf06ee2047636732b84bf2f889/lib/utils/angularjs.js#L58)

```
 const updater = function ($rootScope) {
    const $scope = $element.scope();

    Object.assign($scope, props);

    $scope.$digest();
    $rootScope.$digest();
  };
```

It seems in my setup, that the updater is called within a digest cycle in progress. Not sure why. When running the examples it does not happens. My setup include monorepo and storybook 6.

To mitigate it, I wrapped the scope prop assignment in `asyncApply`. It works in my case and the examples. 
